### PR TITLE
Orthogonal initialization

### DIFF
--- a/nninit.py
+++ b/nninit.py
@@ -13,6 +13,14 @@ def constant(tensor, val):
     return tensor.fill_(val)
 
 
+def orthogonal(tensor):
+    assert len(tensor.size()) == 2
+    assert tensor.size(0) == tensor.size(1) # Must be a square matrix
+    u, s, v = torch.svd(torch.randn(tensor.size()))
+    
+    return tensor.copy_(u)
+
+
 def _calculate_fan_in_and_fan_out(tensor):
     if len(tensor.size()) == 2: # Linear
         fan_in = tensor.size(1)

--- a/tests.py
+++ b/tests.py
@@ -37,3 +37,14 @@ def test_normal(dims):
 
     p_value = stats.kstest(input_tensor.numpy().flatten(), 'norm', args=(mean, std)).pvalue
     assert p_value > 0.05
+
+
+@mark.parametrize("dims", [10, 100, 200])
+def test_orthogonal(dims):
+    np.random.seed(123)
+    torch.manual_seed(123)
+    input_tensor = torch.randn(dims, dims)
+    nninit.orthogonal(input_tensor)
+    identity = torch.mm(input_tensor, input_tensor.t()) # Orthogonality check
+    check = torch.eq(identity, torch.eye(input_tensor.size(0)))
+    assert check.sum() == input_tensor.size(0) * input_tensor.size(1)


### PR DESCRIPTION
Orthogonal initialization thats typically used in hidden-hidden weights in RNNs